### PR TITLE
Fixed crystal ball

### DIFF
--- a/game/src/client/scenes/raceGame/QuestionScene.ts
+++ b/game/src/client/scenes/raceGame/QuestionScene.ts
@@ -305,11 +305,13 @@ export default class QuestionScene extends Phaser.Scene {
 	private useCrystalBall(): void {
 		//TODO: Make constants of the types
 		if (this.question.getAnswerType() == "MULTIPLE_CHOICE" || this.question.getAnswerType() == "MULTIPLE_CHOICE_5") {
-			try {
-				sceneEvents.emit(EventNames.useCrystalBall, ItemType.CrystalBall);
-				this.question.removeWrongAnswer();
-			} catch (error) {
-				console.log(error);
+			if (!this.question.areAllAnswersRight()) {
+				try {
+					sceneEvents.emit(EventNames.useCrystalBall, ItemType.CrystalBall);
+					this.question.removeWrongAnswer();
+				} catch (error) {
+					console.log(error);
+				}
 			}
 		} else {
 			alert("must be a multiple choice question");

--- a/game/src/communication/race/DataInterfaces.ts
+++ b/game/src/communication/race/DataInterfaces.ts
@@ -104,7 +104,7 @@ export interface QuestionDTO {
 export interface AnswerDTO {
 	id: number;
 	label: string;
-	isKnownAsRight: boolean;
+	isRight: boolean;
 }
 
 export interface InfoForQuestion {

--- a/game/src/communication/race/DataInterfaces.ts
+++ b/game/src/communication/race/DataInterfaces.ts
@@ -104,6 +104,7 @@ export interface QuestionDTO {
 export interface AnswerDTO {
 	id: number;
 	label: string;
+	isKnownAsRight: boolean;
 }
 
 export interface InfoForQuestion {

--- a/game/src/gameCore/race/ServerRaceGameController.ts
+++ b/game/src/gameCore/race/ServerRaceGameController.ts
@@ -255,7 +255,7 @@ export default class ServerRaceGameController extends RaceGameController impleme
 						let answerIsRight = false;
 						if (correspondingAnswer !== undefined) {
 							answerIsRight =
-								correspondingAnswer.isKnownAsRight() ||
+								correspondingAnswer.getIsRight() ||
 								clientAnswerLabel == "42, The Answer to the Ultimate Question of Life, the Universe, and Everything"; //DEBUG
 						}
 						const questionId = player.getActiveQuestion().getId();

--- a/game/src/gameCore/race/question/Answer.ts
+++ b/game/src/gameCore/race/question/Answer.ts
@@ -38,6 +38,7 @@ export class Answer {
 		return {
 			id: this.id,
 			label: this.label,
+			isKnownAsRight: this.isKnownAsRight(),
 		};
 	}
 }

--- a/game/src/gameCore/race/question/Answer.ts
+++ b/game/src/gameCore/race/question/Answer.ts
@@ -3,15 +3,15 @@ import { AnswerDTO } from "../../../communication/race/DataInterfaces";
 export class Answer {
 	private id: number;
 	private label: string;
-	private knownAsRight: boolean;
+	private isRight: boolean;
 	constructor(id: number, label: string, isRight?: boolean) {
 		this.id = id;
 		this.label = label;
 		//TODO: rethink implementation (maybe seperate client answers from server answers)
 		if (isRight !== undefined && isRight != null) {
-			this.knownAsRight = isRight;
+			this.isRight = isRight;
 		} else {
-			this.knownAsRight = false;
+			this.isRight = false;
 		}
 	}
 
@@ -19,8 +19,8 @@ export class Answer {
 		return this.id;
 	}
 
-	public isKnownAsRight(): boolean {
-		return this.knownAsRight;
+	public getIsRight(): boolean {
+		return this.isRight;
 	}
 
 	public getLabel(): string {
@@ -38,7 +38,7 @@ export class Answer {
 		return {
 			id: this.id,
 			label: this.label,
-			isKnownAsRight: this.isKnownAsRight(),
+			isRight: this.getIsRight(),
 		};
 	}
 }

--- a/game/src/gameCore/race/question/Question.ts
+++ b/game/src/gameCore/race/question/Question.ts
@@ -41,7 +41,7 @@ export class Question {
 	}
 
 	public getRightAnswer(): Answer {
-		return this.answers.find((answer) => answer.isKnownAsRight());
+		return this.answers.find((answer) => answer.getIsRight());
 	}
 
 	public getAnswerType(): string {
@@ -61,12 +61,12 @@ export class Question {
 	}
 
 	public areAllAnswersRight(): boolean {
-		return this.answers.every((answer) => answer.isKnownAsRight());
+		return this.answers.every((answer) => answer.getIsRight());
 	}
 
 	public removeWrongAnswer(): void {
-		const rightAnswers: Answer[] = this.answers.filter((answer) => answer.isKnownAsRight());
-		const wrongAnswers: Answer[] = this.answers.filter((answer) => !answer.isKnownAsRight());
+		const rightAnswers: Answer[] = this.answers.filter((answer) => answer.getIsRight());
+		const wrongAnswers: Answer[] = this.answers.filter((answer) => !answer.getIsRight());
 		wrongAnswers.splice(Math.floor(Math.random() * wrongAnswers.length), 1);
 		this.answers = wrongAnswers.concat(rightAnswers);
 	}

--- a/game/src/gameCore/race/question/Question.ts
+++ b/game/src/gameCore/race/question/Question.ts
@@ -60,7 +60,10 @@ export class Question {
 		return this.difficulty;
 	}
 
-	//returns true if there was a wrong question remaining and false if there was none
+	public areAllAnswersRight(): boolean {
+		return this.answers.every((answer) => answer.isKnownAsRight());
+	}
+
 	public removeWrongAnswer(): void {
 		const rightAnswers: Answer[] = this.answers.filter((answer) => answer.isKnownAsRight());
 		const wrongAnswers: Answer[] = this.answers.filter((answer) => !answer.isKnownAsRight());

--- a/game/src/gameCore/race/question/QuestionMapper.ts
+++ b/game/src/gameCore/race/question/QuestionMapper.ts
@@ -15,11 +15,11 @@ export default class QuestionMapper {
 
 	private static mapAnswersFromDTO(answers: AnswerDTO[]): Answer[] {
 		return answers.map((answerDTO) => {
-			return new Answer(answerDTO.id, answerDTO.label);
+			return new Answer(answerDTO.id, answerDTO.label, answerDTO.isKnownAsRight);
 		});
 	}
 
 	public static mapAnswer(answerDTO: AnswerDTO): Answer {
-		return new Answer(answerDTO.id, answerDTO.label);
+		return new Answer(answerDTO.id, answerDTO.label, answerDTO.isKnownAsRight);
 	}
 }

--- a/game/src/gameCore/race/question/QuestionMapper.ts
+++ b/game/src/gameCore/race/question/QuestionMapper.ts
@@ -15,11 +15,11 @@ export default class QuestionMapper {
 
 	private static mapAnswersFromDTO(answers: AnswerDTO[]): Answer[] {
 		return answers.map((answerDTO) => {
-			return new Answer(answerDTO.id, answerDTO.label, answerDTO.isKnownAsRight);
+			return new Answer(answerDTO.id, answerDTO.label, answerDTO.isRight);
 		});
 	}
 
 	public static mapAnswer(answerDTO: AnswerDTO): Answer {
-		return new Answer(answerDTO.id, answerDTO.label, answerDTO.isKnownAsRight);
+		return new Answer(answerDTO.id, answerDTO.label, answerDTO.isRight);
 	}
 }


### PR DESCRIPTION
La balle de cristal est gérée côté client. J'ai redonné l'info de "isRight" au client pour qu'il puisse gérer ça par lui-même. Si un jour on ressent le besoin de laisser ce rôle au serveur, on pourra toujours le changer, mais pour le moment, je ne vois pas l'intérêt de devoir demander ça au serveur.

De plus, j'ai ajouté une vérification dans l'utilisation de la boule de cristal pour faire en sorte que l'item ne puisse pas être utilisé si jamais toutes les mauvaises réponses ont déjà été enlevées.