### PR TITLE
waiting room to in game transition

### DIFF
--- a/game/src/client/scenes/WaitingRoomScene.ts
+++ b/game/src/client/scenes/WaitingRoomScene.ts
@@ -1,4 +1,4 @@
-import { GameEndEvent, GameOptions, GameStartEvent, HostChangeEvent, PlayerEndState } from "../../communication/race/DataInterfaces";
+import { GameCreatedEvent, GameEndEvent, GameOptions, HostChangeEvent, PlayerEndState } from "../../communication/race/DataInterfaces";
 import { CLIENT_EVENT_NAMES } from "../../communication/race/EventNames";
 import PlayerState from "../../communication/race/PlayerState";
 import { RoomInfoEvent, RoomSettings } from "../../communication/room/DataInterfaces";
@@ -48,7 +48,7 @@ export default class WaitingRoomScene extends Phaser.Scene {
 		this.highScore = getUserHighScore();
 
 		this.gameSocket = data.socket;
-		this.gameSocket.once(CLIENT_EVENT_NAMES.GAME_START, (gameInfo: GameStartEvent) => {
+		this.gameSocket.once(CLIENT_EVENT_NAMES.GAME_CREATED, (gameInfo: GameCreatedEvent) => {
 			const raceGame: ClientRaceGameController = RaceGameFactory.createClient(
 				gameInfo.gameTime,
 				gameInfo.gameStartTimeStamp,

--- a/game/src/client/scenes/raceGame/RaceGameUI.ts
+++ b/game/src/client/scenes/raceGame/RaceGameUI.ts
@@ -270,7 +270,6 @@ export default class RaceGameUI extends Phaser.Scene {
 		}
 
 		//setting remaining time
-		const GO_DURATION = 1000;
 		const timeRemaining = raceScene.raceGame.getTimeRemaining();
 		if (timeRemaining < 0) {
 			this.setRemainingTimeText(0);

--- a/game/src/client/scenes/raceGame/RaceGameUI.ts
+++ b/game/src/client/scenes/raceGame/RaceGameUI.ts
@@ -3,10 +3,13 @@ import { EventNames, sceneEvents, subscribeToEvent } from "./RaceGameEvents";
 import RaceScene from "./RaceScene";
 
 export default class RaceGameUI extends Phaser.Scene {
+	gameDuration: number;
+
 	disabledInteractionZone: Phaser.GameObjects.Zone;
 
-	remainingTime: Phaser.GameObjects.Text;
+	startCountdownText: Phaser.GameObjects.Text;
 	remainingTimeText: Phaser.GameObjects.Text;
+	remainingTimeLabelText: Phaser.GameObjects.Text;
 	startOptionsButton: Phaser.GameObjects.Image;
 
 	isFollowingPlayer: boolean;
@@ -35,8 +38,9 @@ export default class RaceGameUI extends Phaser.Scene {
 	create() {
 		const raceScene: RaceScene = <RaceScene>this.scene.get(CST.SCENES.RACE_GAME);
 		const currentPlayer = raceScene.raceGame.getCurrentPlayer();
+		this.gameDuration = raceScene.raceGame.getGameDuration();
 
-		this.isFollowingPlayer = false;
+		this.isFollowingPlayer = true;
 		this.isThrowingBanana = false;
 
 		this.playerStatusText = this.add
@@ -64,7 +68,7 @@ export default class RaceGameUI extends Phaser.Scene {
 			)
 			.setScrollFactor(0);
 
-		this.remainingTime = this.add
+		this.remainingTimeText = this.add
 			.text(150, 50, raceScene.raceGame.getTimeRemaining().toString(), {
 				fontFamily: "Courier",
 				fontSize: "32px",
@@ -74,12 +78,22 @@ export default class RaceGameUI extends Phaser.Scene {
 			})
 			.setScrollFactor(0);
 
-		this.remainingTimeText = this.add
+		this.remainingTimeLabelText = this.add
 			.text(50, 50, "Time: ", {
 				fontFamily: "Courier",
 				fontSize: "32px",
 				align: "center",
 				color: "#FDFFB5",
+				fontStyle: "bold",
+			})
+			.setScrollFactor(0);
+
+		this.startCountdownText = this.add
+			.text(600, 200, "", {
+				fontFamily: "Courier",
+				fontSize: "120px",
+				align: "center",
+				color: "#FFFFFF",
 				fontStyle: "bold",
 			})
 			.setScrollFactor(0);
@@ -178,7 +192,7 @@ export default class RaceGameUI extends Phaser.Scene {
 			.setScrollFactor(0);
 
 		this.followPlayerText = this.add
-			.text(50, 500, "Camera follow: Off", {
+			.text(50, 500, this.isFollowingPlayer ? "Camera follow: On" : "Camera follow: Off", {
 				fontFamily: "Courier",
 				fontSize: "32px",
 				align: "center",
@@ -198,9 +212,9 @@ export default class RaceGameUI extends Phaser.Scene {
 		});
 
 		this.followPlayerText.on("pointerup", () => {
-			const newLabel = this.isFollowingPlayer ? "Camera follow: Off" : "Camera follow: On";
-			this.followPlayerText.setText(newLabel);
 			this.isFollowingPlayer = !this.isFollowingPlayer;
+			const newLabel = this.isFollowingPlayer ? "Camera follow: On" : "Camera follow: Off";
+			this.followPlayerText.setText(newLabel);
 			sceneEvents.emit(EventNames.followPlayerToggle, this.isFollowingPlayer);
 		});
 
@@ -256,14 +270,17 @@ export default class RaceGameUI extends Phaser.Scene {
 		}
 
 		//setting remaining time
-		if (raceScene.raceGame.getTimeRemaining() < 0) {
-			this.remainingTime.setText("0");
+		const GO_DURATION = 1000;
+		const timeRemaining = raceScene.raceGame.getTimeRemaining();
+		if (timeRemaining < 0) {
+			this.setRemainingTimeText(0);
+		} else if (!raceScene.raceGame.getIsGameStarted()) {
+			this.setRemainingTimeText(this.gameDuration);
+			this.setStartCountdownText(timeRemaining - this.gameDuration);
 		} else {
-			this.remainingTime.setText(Math.floor(raceScene.raceGame.getTimeRemaining() / 1000).toString());
+			this.setRemainingTimeText(timeRemaining);
+			this.startCountdownText.setText("");
 		}
-
-		//setting remaining time
-		this.remainingTime.setText(Math.floor(raceScene.raceGame.getTimeRemaining() / 1000).toString());
 
 		//setting player time status
 		this.playerStatusText.setText(currentPlayerStatus.toString().substring(0, currentPlayerStatus.length - 6));
@@ -277,6 +294,24 @@ export default class RaceGameUI extends Phaser.Scene {
 
 		//setting player points
 		this.pointsTotal.setText(currentPlayer.getPoints().toString());
+	}
+
+	/**
+	 * Set the time to display as remaining time.
+	 *
+	 * @param remainingTime Time remaining before the game ends in milliseconds
+	 */
+	private setRemainingTimeText(remainingTime: number): void {
+		this.remainingTimeText.setText(Math.floor(remainingTime / 1000).toString());
+	}
+
+	private setStartCountdownText(remainingTime: number): void {
+		const approxRemainingTime = Math.floor(remainingTime / 1000);
+		if (approxRemainingTime > 0) {
+			this.startCountdownText.setText(approxRemainingTime.toString());
+		} else {
+			this.startCountdownText.setText("GO!");
+		}
 	}
 
 	private resumeGame() {

--- a/game/src/client/scenes/raceGame/RaceScene.ts
+++ b/game/src/client/scenes/raceGame/RaceScene.ts
@@ -75,7 +75,7 @@ export default class RaceScene extends Phaser.Scene {
 		this.physTimestep = 15; //physics checks every 15ms (~66 times/sec - framerate is generally 60 fps)
 		this.characterSprites = [];
 		this.pointsForPosition = [];
-		this.isFollowingPlayer = false;
+		this.isFollowingPlayer = true;
 		this.isThrowingBanana = false;
 		this.currentPlayerMovement = this.raceGame.getCurrentPlayer().getMaxMovementDistance();
 		this.activeTileColor = 0xadff2f;
@@ -147,10 +147,13 @@ export default class RaceScene extends Phaser.Scene {
 		}
 
 		this.targetLocation = this.raceGame.getCurrentPlayer().getMove().getCurrentRenderedPosition(this.getCoreGameToPhaserPositionRendering());
-		this.isReadyToGetPossiblePositions = false;
-		this.activateAccessiblePositions();
+		this.isReadyToGetPossiblePositions = true;
 
 		this.scene.launch(CST.SCENES.RACE_GAME_UI);
+
+		//Initilalize camera
+		this.render();
+		this.handleFollowPlayerToggle(this.isFollowingPlayer);
 
 		subscribeToEvent(EventNames.gameResumed, this.resumeGame, this);
 		subscribeToEvent(EventNames.gamePaused, this.pauseGame, this);
@@ -278,18 +281,20 @@ export default class RaceScene extends Phaser.Scene {
 	}
 
 	private renderAccessiblePositions() {
-		const currentPlayer = this.raceGame.getCurrentPlayer();
-		const currentPosition = currentPlayer.getMove().getCurrentRenderedPosition(this.getCoreGameToPhaserPositionRendering());
-		if (this.playerHasArrived(currentPosition) && this.isReadyToGetPossiblePositions) {
-			this.activateAccessiblePositions();
-		} else if (
-			//If a player gets affected by a banana or any other state change without moving
-			currentPlayer.getMaxMovementDistance() !== this.currentPlayerMovement &&
-			this.playerHasArrived(currentPosition) &&
-			!currentPlayer.isAnsweringQuestion()
-		) {
-			this.currentPlayerMovement = currentPlayer.getMaxMovementDistance();
-			this.activateAccessiblePositions();
+		if (this.raceGame.getIsGameStarted()) {
+			const currentPlayer = this.raceGame.getCurrentPlayer();
+			const currentPosition = currentPlayer.getMove().getCurrentRenderedPosition(this.getCoreGameToPhaserPositionRendering());
+			if (this.playerHasArrived(currentPosition) && this.isReadyToGetPossiblePositions) {
+				this.activateAccessiblePositions();
+			} else if (
+				//If a player gets affected by a banana or any other state change without moving
+				currentPlayer.getMaxMovementDistance() !== this.currentPlayerMovement &&
+				this.playerHasArrived(currentPosition) &&
+				!currentPlayer.isAnsweringQuestion()
+			) {
+				this.currentPlayerMovement = currentPlayer.getMaxMovementDistance();
+				this.activateAccessiblePositions();
+			}
 		}
 	}
 

--- a/game/src/communication/race/DataInterfaces.ts
+++ b/game/src/communication/race/DataInterfaces.ts
@@ -19,7 +19,7 @@ export interface BookUsedEvent {
 	questionDifficulty: number;
 }
 
-export interface GameStartEvent {
+export interface GameCreatedEvent {
 	gameTime: number;
 	gameStartTimeStamp: number;
 	grid: StartingRaceGridInfo;

--- a/game/src/communication/race/EventNames.ts
+++ b/game/src/communication/race/EventNames.ts
@@ -8,7 +8,7 @@ export const SERVER_EVENT_NAMES = {
 
 //Events the client controller is subscribed to
 export const CLIENT_EVENT_NAMES = {
-	GAME_START: "game-start",
+	GAME_CREATED: "game-created",
 	GAME_INITIALIZED: "game-initialized",
 	GAME_END: "game-end",
 	GAME_UPDATE: "game-update",

--- a/game/src/gameCore/gameState/PreGame.ts
+++ b/game/src/gameCore/gameState/PreGame.ts
@@ -62,6 +62,6 @@ export default class PreGame implements State {
 	}
 
 	private removeSocketEvents(socket: Socket): void {
-		socket.removeAllListeners(CLIENT_EVENT_NAMES.GAME_START);
+		socket.removeAllListeners(CLIENT_EVENT_NAMES.GAME_CREATED);
 	}
 }

--- a/game/src/gameCore/race/RACE_CST.ts
+++ b/game/src/gameCore/race/RACE_CST.ts
@@ -3,7 +3,7 @@ export const RACE_CST = {
 		SPEED: 0.001, //in tile per millisecond.
 	},
 	CIRCUIT: {
-		GAME_MAX_LENGTH: 5 * 60 * 1000, //in milliseconds
+		STARTING_TRANSITION_DURATION: 4 * 1000, //in milliseconds
 		GRID_WIDTH: 20,
 		GRID_HEIGTH: 16,
 		NUMBER_OF_CHECKPOINTS: 5,

--- a/game/src/gameCore/race/RaceGameController.ts
+++ b/game/src/gameCore/race/RaceGameController.ts
@@ -5,16 +5,17 @@ import Item, { ItemType } from "./items/Item";
 import Player from "./player/Player";
 
 export default abstract class RaceGameController {
-	protected readonly gameTime: number; //in milliseconds
+	protected isGameStarted: boolean = false;
+	protected readonly gameDuration: number; //in milliseconds
 	protected timeRemaining: number;
 	protected readonly gameStartTimeStamp: number;
 	protected grid: RaceGrid;
 	protected players: Player[] = [];
 	protected items: Item[];
 
-	constructor(gameTime: number, gameStartTimeStamp: number, grid: RaceGrid, players: Player[]) {
-		this.gameTime = gameTime;
-		this.timeRemaining = gameTime;
+	constructor(gameDuration: number, gameStartTimeStamp: number, grid: RaceGrid, players: Player[]) {
+		this.gameDuration = gameDuration;
+		this.timeRemaining = gameDuration;
 		this.gameStartTimeStamp = gameStartTimeStamp;
 		this.grid = grid;
 		this.players = players;
@@ -28,11 +29,23 @@ export default abstract class RaceGameController {
 	}
 
 	protected gameLogicUpdate(): void {
-		this.timeRemaining = this.gameTime - (Clock.now() - this.gameStartTimeStamp);
+		this.timeRemaining = this.gameDuration - (Clock.now() - this.gameStartTimeStamp);
+		//This boolean expression is divided in two distinct expressions to avoid computing timestamp difference every loop while the game is already started.
+		if (!this.isGameStarted) {
+			if (Clock.now() >= this.gameStartTimeStamp) this.isGameStarted = true;
+		}
 	}
 
 	public getTimeRemaining(): number {
 		return this.timeRemaining;
+	}
+
+	public getIsGameStarted(): boolean {
+		return this.isGameStarted;
+	}
+
+	public getGameDuration(): number {
+		return this.gameDuration;
 	}
 
 	private playersUpdate() {


### PR DESCRIPTION
La mécanique de transition a été programmée. Côté client, pour le moment, j'ai décidé d'utiliser ce temps de transition pour afficher un "Countdown" dans la RaceScene.

Note importante : Cette feature gère la transition Waiting Room vers In Game dans le cas où il est certain à 100% que la game est lancée. Autrement dit, Il ne s'agit pas d'une feature qui, par exemple, couvrirait le scénario d'un countdown dans la waiting room **pouvant être annulé** (comme dans Halo: Reach ou les joueurs peuvent _press X to cancel_). L'objectif de cette feature est de prévoir une certaine animation de départ lorsque la game est lancée pour pas que ça soit "trop sec".