### PR TITLE
Bugfix/questions html generation

### DIFF
--- a/game/src/server/Server.ts
+++ b/game/src/server/Server.ts
@@ -213,8 +213,10 @@ export class Server {
 	private modifyHtml(html: string): string {
 		const dom = new JSDOM(html);
 
+		//Add stylesheet reference
 		dom.window.document.head.innerHTML = `<link rel="stylesheet" href="${process.env.SERVER_API_URL}/question-style.css">`;
 
+		//Manage images link
 		dom.window.document.querySelectorAll("embed").forEach((element) => {
 			let image = dom.window.document.createElement("img");
 			image.src = element.src;
@@ -225,6 +227,8 @@ export class Server {
 			element.src = `${process.env.SERVER_API_URL}/question-image/${this.renameToSVGFile(element.src)}`;
 		});
 
+		//Problem : In Pandoc, blank spaces for answers ("___") are replaced with <u></u> (which shows nothing).
+		//Solution : Replace <u></u> with "___".
 		dom.window.document.querySelectorAll("u").forEach((element) => {
 			console.log(`inner html: ${element.innerHTML}`);
 			if (element.innerHTML === "") {

--- a/game/src/server/Server.ts
+++ b/game/src/server/Server.ts
@@ -6,6 +6,7 @@ import { JSDOM } from "jsdom";
 import path from "path";
 import "reflect-metadata";
 import ErrorReport from "../communication/ErrorReport";
+import { Question } from "../gameCore/race/question/Question";
 import QuestionRepository from "./data/QuestionRepository";
 import ReportedErrorRepository from "./data/ReportedErrorRepository";
 
@@ -67,6 +68,53 @@ export class Server {
 			const languageShortName = !!req.query.lg ? req.query.lg : "fr";
 
 			res.sendFile(path.join(__dirname, `assets/question_html/answers_html/answer_${answerId}_${languageShortName}.html`));
+		});
+
+		//DEBUG : The goal is to be able to check a whole question quickly
+		this.app.get("/question/:id", async (req, res) => {
+			try {
+				const questionId = req.params.id;
+				const languageShortName = !!req.query.lg ? req.query.lg : "fr";
+				const questionHtml = await fs.promises.readFile(
+					path.join(__dirname, `assets/question_html/questions_html/question_${questionId}_${languageShortName}.html`),
+					{
+						encoding: "utf-8",
+					}
+				);
+				const feedbackHtml = await fs.promises.readFile(
+					path.join(__dirname, `assets/question_html/feedback_html/feedback_${questionId}_${languageShortName}.html`),
+					{
+						encoding: "utf-8",
+					}
+				);
+
+				const question: Question = await this.questionRepo.getQuestionById(Number(questionId), languageShortName.toString());
+				let answersHtml: string[] = [];
+				let i = 0;
+				for (const answer of question.getAnswers()) {
+					const answerHtml = await fs.promises.readFile(
+						path.join(__dirname, `assets/question_html/answers_html/answer_${answer.getId()}_${languageShortName}.html`),
+						{
+							encoding: "utf-8",
+						}
+					);
+					answersHtml[i] = answerHtml;
+					i++;
+				}
+
+				let response: string = "";
+				response += `********** QUESTION (id=${questionId}, lg=${languageShortName}, type=${question.getAnswerType()})**********<br>${questionHtml}`;
+				i = 0;
+				for (const answer of question.getAnswers()) {
+					response += `<br><br>********** ANSWER #${i + 1} (id=${answer.getId()}, isRight=${answer.getIsRight()}) **********<br> ${answersHtml[i]}`;
+					i++;
+				}
+				response += `<br>********** FEEDBACK **********<br><br> ${feedbackHtml}`;
+				res.send(response);
+			} catch (error) {
+				console.log(error);
+				res.send(error);
+			}
 		});
 
 		this.app.post("/errorReport", jsonParser, (req, res) => {
@@ -213,8 +261,14 @@ export class Server {
 	private modifyHtml(html: string): string {
 		//Problem : In Pandoc, "\begin{wrapfigure}[lineheight]{position}{width} [...] \end{wrapfigure}" is replaced with "<div class="wrapfigure"><span>r</span>[0pt]<span>0pt</span> [...] </div>".
 		//Solution :
-		const WRAPFIG_MESSY_CONVERSION = "<span>r</span>[0pt]<span>0pt</span>";
-		html = html.replace(WRAPFIG_MESSY_CONVERSION, "");
+		const WRAPFIG_MESSY_CONVERSIONS = [
+			"<span>r</span>[0pt]<span>0pt</span>",
+			"<span>r</span>[0 pt]<span>0 pt</span>",
+			"<span>r</span>[0 pt]<span>0pt</span>",
+		];
+		WRAPFIG_MESSY_CONVERSIONS.forEach((WRAPFIG_MESSY_CONVERSION) => {
+			html = html.replace(WRAPFIG_MESSY_CONVERSION, "");
+		});
 
 		const dom = new JSDOM(html);
 

--- a/game/src/server/data/QuestionRepository.ts
+++ b/game/src/server/data/QuestionRepository.ts
@@ -2,7 +2,7 @@ import { Question } from "../../gameCore/race/question/Question";
 
 export default interface QuestionRepository {
 	getQuestionsIdByDifficulty(language: string, schoolGradeId: number, difficulty: number): Promise<number[]>;
-	getQuestionById(questionId: number, language: string, schoolGradeId: number): Promise<Question>;
+	getQuestionById(questionId: number, language: string, schoolGradeId?: number): Promise<Question>;
 	getAllQuestions(): Promise<any[]>;
 	getAllAnswers(): Promise<any[]>;
 }

--- a/question_html/question-style.css
+++ b/question_html/question-style.css
@@ -1,3 +1,12 @@
 p {
     font-family: Verdana, Geneva, Tahoma, sans-serif;
 }
+
+.wrapfigure {
+    float: right;
+    padding: 5px;
+}
+
+.scriptsize {
+    font-size:small;
+}


### PR DESCRIPTION
I changed a few things in the modify-html get function so that a few noticed bugs in Panda are fixed. 
I also changed the getQuestionById function so that we can fetch a question without the need to specify the SchoolLevelId. Obviously, when the schoolLevelId is not specified, this means that the returned question doesn't have a difficulty (the difficulty depends on the school level).
I also added a new get command "question" which returns an html page including the specified question, the possible answers and the feedback. This page's goal is to make it easier to see specific questions and hunt nasty bugs!