### PR TITLE
Feature/add flexibility in html references

### DIFF
--- a/game/src/server/Server.ts
+++ b/game/src/server/Server.ts
@@ -274,7 +274,7 @@ export class Server {
 		const dom = new JSDOM(html);
 
 		//Add stylesheet reference
-		dom.window.document.head.innerHTML = `<link rel="stylesheet" href="${process.env.SERVER_API_URL}/question-style.css">`;
+		dom.window.document.head.innerHTML = `<link rel="stylesheet" href="../question-style.css">`;
 
 		//Problem : Some "img" tags are replaced with "embed" tags
 		//Solution :
@@ -287,8 +287,8 @@ export class Server {
 
 		//Image source link has to be specified
 		dom.window.document.querySelectorAll("img").forEach((element) => {
-			if (!element.src.includes(`${process.env.SERVER_API_URL}/question-image/`)) {
-				element.src = `${process.env.SERVER_API_URL}/question-image/${this.renameToSVGFile(element.src)}`;
+			if (!element.src.includes(`../question-image/`)) {
+				element.src = `../question-image/${this.renameToSVGFile(element.src)}`;
 			}
 		});
 


### PR DESCRIPTION
Now, when we modify HTML files (questions, feedbacks, answers), we use relative path for stylesheet and images.